### PR TITLE
Make Factory Bot work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'coffee-rails', '~> 4.2'
 gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
+gem 'warden'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 3.0'
 # Use ActiveModel has_secure_password
@@ -41,6 +42,7 @@ group :development, :test do
   gem 'factory_bot_rails'
   gem 'capybara', '~> 2.13'
   gem 'selenium-webdriver'
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,6 @@ group :development do
   gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,11 +167,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    spring (2.0.2)
-      activesupport (>= 4.2)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -219,8 +214,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   selenium-webdriver
   simplecov
-  spring
-  spring-watcher-listen (~> 2.0.0)
   sqlite3
   turbolinks (~> 5)
   tzinfo-data

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
+    docile (1.1.5)
     erubi (1.7.0)
     execjs (2.7.0)
     factory_bot (4.8.2)
@@ -78,6 +79,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    json (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -160,6 +162,11 @@ GEM
     selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
+    simplecov (0.15.1)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -183,6 +190,8 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.0.2)
       execjs (>= 0.3.0, < 3)
+    warden (1.2.7)
+      rack (>= 1.0)
     web-console (3.5.1)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -209,13 +218,15 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
+  warden
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.13.1
+   1.16.0

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,6 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 
 require 'spec_helper'
-# require 'support/factory_bot'
 require 'simplecov'
 SimpleCov.start
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,57 +1,27 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
-# Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
-# Add additional requires below this line. Rails is not loaded until this point!
 
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+require 'spec_helper'
+require 'support/factory_bot'
+require 'simplecov'
+SimpleCov.start
 
-# Checks for pending migrations and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
+  include Warden::Test::Helpers
   config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-  config.infer_spec_type_from_file_location!
+  config.after :each do
+    Warden.test_reset!
+  end
 
-  # Filter lines from Rails gems in backtraces.
+  config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 
 require 'spec_helper'
-require 'support/factory_bot'
+# require 'support/factory_bot'
 require 'simplecov'
 SimpleCov.start
 


### PR DESCRIPTION
Hi. I was a little busy today so I wasn't able to reply to your message on IRC. I think a PR will be fine instead.

Here's what I said:

```
[14:52:09]  <Radar>	Note also in your Gist that you _are_ manually requiring your factories file, and it's broken
[14:52:19]  <Radar>	So maybe stop requiring the file? That's probably what's happening. It's being loaded twice.
```

And then you said:

```
[14:52:55]  <amperry>	which file, which line?
[14:53:11]  <amperry>	oh, I think I see.
```

But then...

```
[15:05:49]  <amperry>	ah well, back to fixtures it is. Thanks, all.
```

I'd really rather you not go back to fixtures because they get pretty unwieldy after a while.

---

So in this little project, you've got a file at `spec/support/factory_bot.rb` and another file at `spec/factories/user.rb`. Both of these files define a `:user` factory, and so if you require `support/factory_bot` in `rails_helper`, it will fail with the error you were seeing. Check out to 
351313f and you'll see what I mean:

```
git checkout 351313f 
```

You can remove `spec/support/factory_bot.rb` and define your factories in the `spec/factories` directory instead. This is the approved way. It's also worth noting that anything in `spec/factories` is automatically loaded by the `factory_bot_rails` gem. The README is a little obtuse WRT to this, but I'll make it clear:

**By having `factory_bot_rails` installed, anything in `spec/factories` is automatically loaded when running your tests**

So yeah, it's likely that in your project you've either got two things requiring the factories file, or you're defining the factories twice. If you're manually requiring the factories file then that's probably the cause. Comment out that line that's like `require 'support/factory_bot` and see if you still see the issue.